### PR TITLE
Adding two commands: Prev/Next Blank Line

### DIFF
--- a/Line/Info.plist
+++ b/Line/Info.plist
@@ -32,6 +32,22 @@
 					<key>XCSourceEditorCommandClassName</key>
 					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
 					<key>XCSourceEditorCommandIdentifier</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).NextBlankLine</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Next Blank Line</string>
+				</dict>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
+					<string>$(PRODUCT_BUNDLE_IDENTIFIER).PrevBlankLine</string>
+					<key>XCSourceEditorCommandName</key>
+					<string>Pevious Blank Line</string>
+				</dict>
+				<dict>
+					<key>XCSourceEditorCommandClassName</key>
+					<string>$(PRODUCT_MODULE_NAME).SourceEditorCommand</string>
+					<key>XCSourceEditorCommandIdentifier</key>
 					<string>$(PRODUCT_BUNDLE_IDENTIFIER).MoveLineUp</string>
 					<key>XCSourceEditorCommandName</key>
 					<string>Move Line Up</string>


### PR DESCRIPTION
These commands let you move up or down in a document by jumping to blank lines.

The cursor position does change but, for some reason I don't yet understand yet, the view doesn't follow the cursor.